### PR TITLE
CRN-1299 Support for inline pdfs and videos

### DIFF
--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -350,3 +350,78 @@ parseTest(
     },
     'Single JPEG image.'
 );
+
+parseTest(
+    '<iframe src="https://vimeo.com/video">',
+    {
+        data: {},
+        content: [
+            {
+                data: {
+                    target: {
+                        sys: {
+                            type: 'Link',
+                            linkType: 'Entry',
+                            id: '1564116844',
+                        },
+                    },
+                },
+                content: [],
+                nodeType: 'embedded-entry-inline',
+            },
+        ],
+        nodeType: 'document',
+    },
+    'Single iframe'
+);
+
+parseTest(
+    '<p>Video <iframe src="https://vimeo.com/video"></p><p>PDF <iframe src="https://drive.com/file"></p>',
+    {
+        data: {},
+        content: [
+            {
+                data: {},
+                content: [
+                    { data: {}, marks: [], value: 'Video ', nodeType: 'text' },
+                    {
+                        data: {
+                            target: {
+                                sys: {
+                                    type: 'Link',
+                                    linkType: 'Entry',
+                                    id: '1564116844',
+                                },
+                            },
+                        },
+                        content: [],
+                        nodeType: 'embedded-entry-inline',
+                    },
+                ],
+                nodeType: 'paragraph',
+            },
+            {
+                data: {},
+                content: [
+                    { data: {}, marks: [], value: 'PDF ', nodeType: 'text' },
+                    {
+                        data: {
+                            target: {
+                                sys: {
+                                    type: 'Link',
+                                    linkType: 'Entry',
+                                    id: '523299395',
+                                },
+                            },
+                        },
+                        content: [],
+                        nodeType: 'embedded-entry-inline',
+                    },
+                ],
+                nodeType: 'paragraph',
+            },
+        ],
+        nodeType: 'document',
+    },
+    'Multiple iframes'
+);


### PR DESCRIPTION
Jira Ticket: https://asaphub.atlassian.net/browse/CRN-1299

This PR is tied to https://github.com/yldio/asap-hub/pull/2540 from the ASAP Hub.

---

This PR handles `iframe` tags in the rich text. These `iframe` tags are found in inline PDFs and videos.

In order to do that, we need to create an entry in a separate content type (reference https://www.contentfulcommunity.com/t/embed-youtube-or-vimeo-video-directly-into-rich-text-content-type/2639). So we need to have the payload to upload an entry and link this entry to the node block of the generated json output.

- The function `parseIFrames` creates the body necessary to upload the entries on contentful.
- The snippet inside `transformDom` creates the node block corresponding to the inline entry with the entry link.