### PR TITLE
CT-65 fix case where we have hyperlink inside heading

### DIFF
--- a/index.js
+++ b/index.js
@@ -191,10 +191,18 @@ const transformDom = (dom, parents = [], getAssetId) => {
             content = transformDom(children, newParents);
         }
 
-        if (
-            !newParents.includes("paragraph") &&
-            !newParents.includes("list-item")
-        ) {
+        const topLevelElements = [
+            "paragraph",
+            "list-item",
+            "heading-1",
+            "heading-2",
+            "heading-3",
+            "heading-4",
+            "heading-5",
+            "heading-6"
+        ];
+
+        if (!topLevelElements.some(element => newParents.includes(element))) {
             content = enforceTopLevelParagraphs(content);
         }
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -468,3 +468,75 @@ parseTest(
     },
     "Multiple iframes"
 );
+
+[
+    {tag: 'h1', nodeType: 'heading-1'},
+    {tag: 'h2', nodeType: 'heading-2'},
+    {tag: 'h3', nodeType: 'heading-3'},
+    {tag: 'h4', nodeType: 'heading-4'},
+    {tag: 'h5', nodeType: 'heading-5'},
+    {tag: 'h6', nodeType: 'heading-6'}
+].forEach(({tag, nodeType}) => {
+    parseTest(`<${tag}><span style=\\"font-weight: 400;\\">Team Presenting: </span><strong>Team Desjardins - <a href=\\"<https://cloud.squidex.io/app/asap-hub/content/users/da7638a9-6cfb-460f-b931-2569a8947f68\\>" target=\\"_blank\\" rel=\\"noopener\\">Heidi McBride</a></strong></${tag}>`, {
+        "data": {},
+        "content": [
+            {
+                "data": {},
+                "content": [
+                    {
+                        "data": {},
+                        "marks": [],
+                        "value": "Team Presenting: ",
+                        "nodeType": "text"
+                    },
+                    {
+                        "data": {},
+                        "marks": [
+                            {
+                                "type": "bold"
+                            }
+                        ],
+                        "value": "Team Desjardins - ",
+                        "nodeType": "text"
+                    },
+                    {
+                        "data": {
+                            "uri": "\\"
+                        },
+                        "content": [
+                            {
+                                "data": {},
+                                "content": [
+                                    {
+                                        "data": {},
+                                        "marks": [
+                                            {
+                                                "type": "bold"
+                                            }
+                                        ],
+                                        "value": "\" target=\\\"_blank\\\" rel=\\\"noopener\\\"",
+                                        "nodeType": "text"
+                                    },
+                                    {
+                                        "data": {},
+                                        "marks": [
+                                            {
+                                                "type": "bold"
+                                            }
+                                        ],
+                                        "value": "Heidi McBride",
+                                        "nodeType": "text"
+                                    }
+                                ]
+                            }
+                        ],
+                        "nodeType": "hyperlink"
+                    }
+                ],
+                "nodeType": nodeType
+            }
+        ],
+        "nodeType": "document"
+    }, `hyperlink inside ${nodeType}`)
+})
+


### PR DESCRIPTION
Contentful gives an error like the one below

![Screenshot 2023-06-13 at 06 34 35](https://github.com/yldio/contentful-html-rich-text-converter/assets/16595804/131de4f2-7ad1-4cf4-a957-f677bd2ee542)

when we have a paragraph inside a heading. This was happening when we had an `<a>` tag inside a heading. Like in this html

```
<h4>
    <span style=\\"font-weight: 400;\\">Team Presenting: </span>
    <strong>Team Desjardins - <a href=\\"<https://cloud.squidex.io/app/asap-hub/content/users/da7638a9-6cfb-460f-b931-2569a8947f68\\>" target=\\"_blank\\" rel=\\"noopener\\">Heidi McBride</a>
    </strong>
</h4>
```

So in this PR I'm adding headings to the list of parent elements that makes the code **don't** call `enforceTopLevelParagraphs` where the node paragraph was being added when we have hyperlink:


```
const enforceTopLevelParagraphs = (content) => {
    return content.map((node) => {
        if (node.nodeType === "hyperlink" || node.nodeType === "br") {
            return {
                data: {},
                content: [node],
                nodeType: "paragraph",
            };
        }

        return node;
    });
};
```